### PR TITLE
Add an option to set height and color via CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ plugins: ['gatsby-plugin-page-progress']
 | height        | `Number`                  | 3       | ❌        | Sets the height of the progress bar.                                                                                                                                                                                                                |
 | color         | `String`                  | #663399 | ❌        | Sets the color of the progress bar.                                                                                                                                                                                                                 |
 
+## Options in CSS
+
+It is possible to set _height_ and _color_ options via CSS:
+
+```css
+/* style.css */
+
+#gatsby-plugin-page-progress {
+    height: 3px;
+    background-color: #663399;
+}
+```
+
+```js
+/* gatsby-browser.js */
+
+import './style.css'
+```
+
+**Note** that any option set via the plugin options in `gatsby-config.js` will override thse CSS settings.
+
 ## Examples
 
 #### Only include the root path:

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,9 +1,11 @@
+import './progress.css'
+
 const defaultOptions = {
   includePaths: [],
   excludePaths: [],
-  height: 3,
+  height: null,
   prependToBody: false,
-  color: `#663399`,
+  color: null,
 };
 
 // browser API usage: https://www.gatsbyjs.org/docs/browser-apis/#onRouteUpdate
@@ -28,6 +30,14 @@ export const onRouteUpdate = (
     // set defaults and grab progress indicator from the DOM
     let scrolling = false;
     const indicator = document.getElementById(`gatsby-plugin-page-progress`);
+
+    if (height != null) {
+      indicator.style.height = `${height}px`;
+    }
+
+    if (color != null) {
+      indicator.style.backgroundColor = color;
+    }
 
     // determine width of progress indicator
     const getIndicatorPercentageWidth = (currentPos, totalScroll) => {
@@ -60,13 +70,7 @@ export const onRouteUpdate = (
             currentPos,
             scrollDistance
           );
-
-          indicator.setAttribute(
-            `style`,
-            // eslint-disable-next-line
-            `width: ${indicatorWidth}%; position: fixed; height: ${height}px; background-color: ${color}; top: 0; left: 0; transition: width 0.25s;`
-          );
-
+          indicator.style.width = indicatorWidth + '%';
           scrolling = false;
         });
         scrolling = true;

--- a/src/progress.css
+++ b/src/progress.css
@@ -1,0 +1,8 @@
+#gatsby-plugin-page-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    transition: width 0.25s;
+    height: 3px;
+    background-color: #663399;
+}


### PR DESCRIPTION
Implements #18.

Take a look at the `README.md` changes for instructions on how to achieve this functionality. This shouldn't brake current customization via plugin options in `gatsby-config.js` as these options take precedence over the CSS settings.