### PR TITLE
chore: Add "prepare" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . && uglifyjs gatsby-browser.js -cm -o gatsby-browser.js",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "clean": "rm -rf node_modules",
     "watch": "babel -w src --out-dir .",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . && uglifyjs gatsby-browser.js -cm -o gatsby-browser.js",
+    "prepare": "npm run build",
     "clean": "rm -rf node_modules",
     "watch": "babel -w src --out-dir .",
     "lint": "eslint .",


### PR DESCRIPTION
Hi!

I took me some time to figure out that you forgot in your 2.0.11 release to build and push the gatsby-browser.js to npm (see https://unpkg.com/browse/gatsby-plugin-page-progress@2.0.10/ vs https://unpkg.com/browse/gatsby-plugin-page-progress@2.0.11/). By adding `prepare` (https://docs.npmjs.com/misc/scripts) this shouldn't happen anymore. Feel free to edit it to e.g. `prepublishOnly` if you like that more.