### PR TITLE
add high z-index to ensure progress bar shows above everything else

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -58,7 +58,7 @@ export const onRouteUpdate = ({ location: { pathname } }, pluginOptions = {}) =>
           indicator.setAttribute(
             `style`,
             // eslint-disable-next-line
-            `width: ${indicatorWidth}%; position: fixed; height: ${height}px; background-color: ${color}; top: 0; left: 0; transition: width 0.25s;`
+            `width: ${indicatorWidth}%; position: fixed; height: ${height}px; background-color: ${color}; top: 0; left: 0; transition: width 0.25s; z-index: 9999;`
           );
 
           scrolling = false;


### PR DESCRIPTION
Hey there, love this plugin! It wasn't showing up when I first set it up and I quickly realized it was rendering below my header block bc of a z-index thing.

If you set a z-index over 1 for anything at the top of the viewport it will obscure the progress bar so all we have to do is set a really high z-index to ensure that this renders above all else.

Thanks for the awesome plugin, saved me a ton of time! 